### PR TITLE
Fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ they are *pinned*, i.e. of the form ```abc==1.2.3```.
 
 ## Installation
 
-* `pip install puck`
+```
+$ git clone https://github.com/NativeInstruments/puck.git
+$ cd puck
+$ pip install .
+```
+
+*installation from PyPI coming soon* 
 
 ## Usage
 


### PR DESCRIPTION
Since `puck` is taken on PyPI I added manual installation steps for now.